### PR TITLE
Fix <App /> was created with unknown prop logs

### DIFF
--- a/src/lib/components/App.svelte
+++ b/src/lib/components/App.svelte
@@ -4,8 +4,8 @@
   import Render, { h } from './Render.svelte'
   import store from '../store'
 
-  export const initialPage: Page | null = null
-  export const resolveComponent: ComponentResolver | null = null
+  export let initialPage: Page | null = null
+  export let resolveComponent: ComponentResolver | null = null
 
   $: child = $store.component && h($store.component.default, $store.page?.props)
   $: layout = $store.component && $store.component.layout


### PR DESCRIPTION
I'm assuming Svelte is squawking at these being readonly props, changing them to `let` seems to remove the warnings that populate the console during development.