### PR TITLE
fix: `useForm`

### DIFF
--- a/src/lib/useForm.ts
+++ b/src/lib/useForm.ts
@@ -182,7 +182,6 @@ export default function useForm<TForm extends Record<string, unknown>>(
           this.setStore('processing', false)
           this.setStore('progress', null)
           this.clearErrors()
-          this.defaults()
           this.setStore('wasSuccessful', true)
           this.setStore('recentlySuccessful', true)
           recentlySuccessfulTimeoutId = setTimeout(() => this.setStore('recentlySuccessful', false), 2000)


### PR DESCRIPTION
Get rid of `defaults()` method call inside `onSuccess()` callback that sets the current form values as the new defaults. Which causes unexpected behavior if end-users use this callback e.g., resetting the form and form cycle